### PR TITLE
gte-common: We are number 1

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -13,6 +13,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+# SEPolicy
+CONFIG_GTE_COMMON_SEPOLICY := true
+
 # Inherit from common
 include device/samsung/msm8916-common/BoardConfigCommon.mk
 
@@ -37,6 +40,4 @@ TARGET_PROVIDES_FM_RADIO := false
 # Keymaster
 TARGET_PROVIDES_KEYMASTER := true
 
-# SEPolicy
-CONFIG_GTE_COMMON_SEPOLICY := true
 DEVICE_SEPOLICY_DIRS += device/samsung/gte-common/sepolicy

--- a/sepolicy/charger.te
+++ b/sepolicy/charger.te
@@ -1,4 +1,0 @@
-#============= charger ==============
-allow charger sysfs:file read;
-allow charger sysfs:file open;
-allow charger device:dir r_dir_perms;


### PR DESCRIPTION
Making CONFIG_GTE_COMMON_SEPOLICY number 1 allow the device to build/boot with sepolicy enforced